### PR TITLE
Add ChatGPT integration endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,25 @@
+# Driftclub Backend API
+
+This project uses Next.js API routes to serve data.
+
+## OpenAI Chat Endpoint
+
+A new API route is available at `/api/chat`.  It expects a POST request with a JSON body containing an array of ChatGPT-style `messages`.
+
+Example request body:
+
+```json
+{
+  "messages": [{ "role": "user", "content": "Hello" }]
+}
+```
+
+The response will contain the assistant's message in an `answer` field.
+
+Set the `OPENAI_API_KEY` environment variable so the route can access the OpenAI API.
+
+## Using with Botpress
+
+Create a custom action or hook in Botpress that makes a POST request to `/api/chat` and sends the conversation messages.  Parse the `answer` field from the response and continue the workflow with that text.
+
+

--- a/app/api/chat/route.js
+++ b/app/api/chat/route.js
@@ -1,0 +1,30 @@
+import OpenAI from 'openai';
+import { NextResponse } from 'next/server';
+
+export const dynamic = 'force-dynamic';
+
+if (!process.env.OPENAI_API_KEY) {
+  throw new Error('Missing OPENAI_API_KEY environment variable');
+}
+
+const openai = new OpenAI({
+  apiKey: process.env.OPENAI_API_KEY,
+});
+
+export async function POST(req) {
+  try {
+    const { messages } = await req.json();
+
+    const completion = await openai.chat.completions.create({
+      model: 'gpt-3.5-turbo',
+      messages,
+    });
+
+    const answer = completion.choices[0]?.message?.content;
+    return NextResponse.json({ answer });
+  } catch (err) {
+    console.error('OpenAI API error:', err.message);
+    return NextResponse.json({ error: 'Failed to fetch response' }, { status: 500 });
+  }
+}
+

--- a/package.json
+++ b/package.json
@@ -14,5 +14,6 @@
   "googleapis": "^105.0.0",
   "supports-color": "^8.1.1",
   "encoding": "^0.1.13"
+  ,"openai": "^4.26.0"
 }
 }


### PR DESCRIPTION
## Summary
- add `/api/chat` route to call OpenAI API
- document usage in README
- include `openai` dependency

## Testing
- `npm run build` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684585c01e18832db9e9745388160ac2